### PR TITLE
Update proguard rules

### DIFF
--- a/code/edgeconsent/build.gradle
+++ b/code/edgeconsent/build.gradle
@@ -18,7 +18,7 @@ android {
         versionName rootProject.moduleVersion
 
         testInstrumentationRunner rootProject.ext.testInstrumentationRunner
-        consumerProguardFiles "consumer-rules.pro"
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     flavorDimensions "target"

--- a/code/edgeconsent/proguard-rules.pro
+++ b/code/edgeconsent/proguard-rules.pro
@@ -19,3 +19,9 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# keep class names and method names used by reflection
+-keepclassmembers class com.adobe.marketing.mobile.edge.consent.* {
+   protected <init>(...);
+   <init>(...);
+}

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.edge.consent;
 final class ConsentConstants {
 
     static final String LOG_TAG = "Consent";
-    static final String EXTENSION_VERSION = "1.0.0";
+    static final String EXTENSION_VERSION = "1.0.1";
     static final String EXTENSION_NAME = "com.adobe.edge.consent";
 
 	final class EventDataKey {

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -8,7 +8,7 @@ android.enableJetifier=true
 moduleProjectName=edgeconsent
 moduleName=edgeconsent
 moduleAARName=edgeconsent-phone-release.aar
-moduleVersion=1.0.0
+moduleVersion=1.0.1
 
 mavenRepoName=AdobeMobileEdgeConsentSdk
 mavenRepoDescription=Adobe Experience Platform Edge Consent Collection extension for the Adobe Experience Platform Mobile SDK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Update proguard rules for the Consent library to preserve the class members used by reflection for extension registration.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created release lib using make ci-generate-library-release command and linked as dependency to the sample app, then created release APK and tested on emulator.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
