### PR TITLE
Make a clone for callback event data, so getConsent response can be mutable 

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
@@ -40,6 +40,7 @@ public class Consent {
 	 *
 	 * @return The version as {@code String}
 	 */
+	@NonNull
 	public static String extensionVersion() {
 		return ConsentConstants.EXTENSION_VERSION;
 	}
@@ -49,6 +50,7 @@ public class Consent {
 	 * Registers the extension with the Mobile SDK. This method should be called only once in your application class.
 	 * @deprecated Use {@link MobileCore#registerExtensions(List, AdobeCallback)} with {@link Consent#EXTENSION} instead.
 	 */
+	@NonNull
 	@Deprecated
 	public static void registerExtension() {
 		MobileCore.registerExtension(

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
@@ -129,9 +129,7 @@ public class Consent {
 					return;
 				}
 
-				Map<String, Object> copyResult = Utils.deepCopy(event.getEventData());
-				Map<String, Object> responseConsentsData = copyResult != null ? copyResult : new HashMap<>();
-
+				Map<String, Object> responseConsentsData = Utils.optDeepCopy(event.getEventData(), new HashMap<>());
 				callback.call(responseConsentsData);
 			}
 

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
@@ -50,8 +50,8 @@ public class Consent {
 	 * Registers the extension with the Mobile SDK. This method should be called only once in your application class.
 	 * @deprecated Use {@link MobileCore#registerExtensions(List, AdobeCallback)} with {@link Consent#EXTENSION} instead.
 	 */
-	@NonNull
 	@Deprecated
+	@SuppressWarnings("deprecation")
 	public static void registerExtension() {
 		MobileCore.registerExtension(
 			ConsentExtension.class,

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
@@ -22,6 +22,9 @@ import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.util.CloneFailedException;
+import com.adobe.marketing.mobile.util.EventDataUtils;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -124,7 +127,20 @@ public class Consent {
 					returnError(callback, AdobeError.UNEXPECTED_ERROR);
 					return;
 				}
-				callback.call(event.getEventData());
+				Map<String, Object> responseConsentsData = new HashMap<String, Object>();
+
+				try {
+					responseConsentsData = EventDataUtils.clone(event.getEventData());
+				} catch (CloneFailedException ex) {
+					Log.warning(
+						LOG_TAG,
+						LOG_SOURCE,
+						"Failed clone response data, skipping. Exception details: %s",
+						ex.getLocalizedMessage()
+					);
+				}
+
+				callback.call(responseConsentsData);
 			}
 
 			@Override

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.edge.consent;
 
 import static com.adobe.marketing.mobile.edge.consent.ConsentConstants.LOG_TAG;
 
+import androidx.annotation.NonNull;
 import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.AdobeCallbackWithError;
 import com.adobe.marketing.mobile.AdobeError;
@@ -75,7 +76,7 @@ public class Consent {
 	 *
 	 * @param consents A {@link Map} of consents to be merged with the existing consents
 	 */
-	public static void update(final Map<String, Object> consents) {
+	public static void update(@NonNull final Map<String, Object> consents) {
 		if (consents == null || consents.isEmpty()) {
 			Log.debug(LOG_TAG, LOG_SOURCE, "Null/Empty consents passed to update API. Ignoring the API call.");
 			return;
@@ -102,7 +103,7 @@ public class Consent {
 	 *                 when an unexpected error occurs or the request timed out
 	 */
 
-	public static void getConsents(final AdobeCallback<Map<String, Object>> callback) {
+	public static void getConsents(@NonNull final AdobeCallback<Map<String, Object>> callback) {
 		if (callback == null) {
 			Log.debug(
 				LOG_TAG,

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consent.java
@@ -23,8 +23,6 @@ import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.services.Log;
-import com.adobe.marketing.mobile.util.CloneFailedException;
-import com.adobe.marketing.mobile.util.EventDataUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,18 +126,9 @@ public class Consent {
 					returnError(callback, AdobeError.UNEXPECTED_ERROR);
 					return;
 				}
-				Map<String, Object> responseConsentsData = new HashMap<String, Object>();
 
-				try {
-					responseConsentsData = EventDataUtils.clone(event.getEventData());
-				} catch (CloneFailedException ex) {
-					Log.warning(
-						LOG_TAG,
-						LOG_SOURCE,
-						"Failed clone response data, skipping. Exception details: %s",
-						ex.getLocalizedMessage()
-					);
-				}
+				Map<String, Object> copyResult = Utils.deepCopy(event.getEventData());
+				Map<String, Object> responseConsentsData = copyResult != null ? copyResult : new HashMap<>();
 
 				callback.call(responseConsentsData);
 			}

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
@@ -78,6 +78,7 @@ class ConsentExtension extends Extension {
 	 *
 	 * @return unique name of this extension
 	 */
+	@NonNull
 	@Override
 	protected String getName() {
 		return ConsentConstants.EXTENSION_NAME;
@@ -88,6 +89,7 @@ class ConsentExtension extends Extension {
 	 *
 	 * @return unique friendly name of this extension
 	 */
+	@NonNull
 	@Override
 	protected String getFriendlyName() {
 		return ConsentConstants.FRIENDLY_NAME;
@@ -98,6 +100,7 @@ class ConsentExtension extends Extension {
 	 *
 	 * @return the version of this extension
 	 */
+	@NonNull
 	@Override
 	protected String getVersion() {
 		return ConsentConstants.EXTENSION_VERSION;

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consents.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consents.java
@@ -11,9 +11,7 @@
 
 package com.adobe.marketing.mobile.edge.consent;
 
-import com.adobe.marketing.mobile.util.CloneFailedException;
 import com.adobe.marketing.mobile.util.DataReader;
-import com.adobe.marketing.mobile.util.EventDataUtils;
 import com.adobe.marketing.mobile.util.TimeUtils;
 import java.util.Date;
 import java.util.HashMap;
@@ -36,11 +34,8 @@ final class Consents {
 			return;
 		}
 
-		try {
-			this.consentsMap = EventDataUtils.clone(newConsents.consentsMap);
-		} catch (CloneFailedException e) {
-			this.consentsMap = new HashMap<String, Object>();
-		}
+		Map<String, Object> copyResult = Utils.deepCopy(newConsents.consentsMap);
+		this.consentsMap = copyResult != null ? copyResult : new HashMap<>();
 	}
 
 	/**
@@ -57,14 +52,11 @@ final class Consents {
 			Object.class,
 			xdmMap,
 			ConsentConstants.EventDataKey.CONSENTS,
-			null
+			new HashMap<>()
 		);
 
-		try {
-			consentsMap = EventDataUtils.clone(allConsents);
-		} catch (final CloneFailedException exp) {
-			consentsMap = new HashMap<>();
-		}
+		Map<String, Object> copyResult = Utils.deepCopy(allConsents);
+		consentsMap = copyResult != null ? copyResult : new HashMap<>();
 	}
 
 	/**
@@ -158,13 +150,9 @@ final class Consents {
 	 * @return {@link Map} representing the Consents in XDM format
 	 */
 	Map<String, Object> asXDMMap() {
-		Map<String, Object> internalConsentMap = null;
-		try {
-			internalConsentMap =
-				consentsMap != null ? EventDataUtils.clone(consentsMap) : new HashMap<String, Object>();
-		} catch (CloneFailedException e) {
-			internalConsentMap = new HashMap<String, Object>();
-		}
+		Map<String, Object> internalConsentMap = consentsMap != null
+			? Utils.deepCopy(consentsMap)
+			: new HashMap<String, Object>();
 		final Map<String, Object> xdmFormattedMap = new HashMap<>();
 
 		xdmFormattedMap.put(ConsentConstants.EventDataKey.CONSENTS, internalConsentMap);

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consents.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Consents.java
@@ -34,8 +34,7 @@ final class Consents {
 			return;
 		}
 
-		Map<String, Object> copyResult = Utils.deepCopy(newConsents.consentsMap);
-		this.consentsMap = copyResult != null ? copyResult : new HashMap<>();
+		this.consentsMap = Utils.optDeepCopy(newConsents.consentsMap, new HashMap<>());
 	}
 
 	/**
@@ -55,8 +54,7 @@ final class Consents {
 			new HashMap<>()
 		);
 
-		Map<String, Object> copyResult = Utils.deepCopy(allConsents);
-		consentsMap = copyResult != null ? copyResult : new HashMap<>();
+		consentsMap = Utils.optDeepCopy(allConsents, new HashMap<>());
 	}
 
 	/**
@@ -150,9 +148,7 @@ final class Consents {
 	 * @return {@link Map} representing the Consents in XDM format
 	 */
 	Map<String, Object> asXDMMap() {
-		Map<String, Object> internalConsentMap = consentsMap != null
-			? Utils.deepCopy(consentsMap)
-			: new HashMap<String, Object>();
+		Map<String, Object> internalConsentMap = Utils.optDeepCopy(consentsMap, new HashMap<String, Object>());
 		final Map<String, Object> xdmFormattedMap = new HashMap<>();
 
 		xdmFormattedMap.put(ConsentConstants.EventDataKey.CONSENTS, internalConsentMap);

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Utils.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Utils.java
@@ -1,0 +1,47 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.consent;
+
+import static com.adobe.marketing.mobile.edge.consent.ConsentConstants.LOG_TAG;
+
+import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.util.CloneFailedException;
+import com.adobe.marketing.mobile.util.EventDataUtils;
+import java.util.Map;
+
+final class Utils {
+
+	private static final String LOG_SOURCE = "Utils";
+
+	private Utils() {}
+
+	/**
+	 * Creates a deep copy of the provided {@link Map}.
+	 *
+	 * @param map to be copied
+	 * @return {@link Map} containing a deep copy of all the elements in {@code map}
+	 */
+	static Map<String, Object> deepCopy(final Map<String, Object> map) {
+		try {
+			return EventDataUtils.clone(map);
+		} catch (CloneFailedException e) {
+			Log.debug(
+				LOG_TAG,
+				LOG_SOURCE,
+				"Unable to deep copy map. CloneFailedException: %s",
+				e.getLocalizedMessage()
+			);
+		}
+
+		return null;
+	}
+}

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Utils.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/Utils.java
@@ -44,4 +44,9 @@ final class Utils {
 
 		return null;
 	}
+
+	static Map<String, Object> optDeepCopy(final Map<String, Object> map, final Map<String, Object> fallback) {
+		Map<String, Object> ret = deepCopy(map);
+		return ret != null ? ret : fallback;
+	}
 }

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
@@ -293,61 +293,14 @@ public class ConsentTest {
 
 			final AdobeCallbackWithError<Event> callbackWithError = callbackCaptor.getValue();
 
-			callbackWithError.call(buildConsentResponseEvent(SAMPLE_CONSENTS_MAP));
-			assertEquals(SAMPLE_CONSENTS_MAP, callbackReturnValues.get(0));
+			Map<String, Object> verifyConsentMap = ConsentTestUtil.CreateConsentXDMMap("y");
+			callbackWithError.call(buildConsentResponseEvent(verifyConsentMap));
+			assertEquals(verifyConsentMap, callbackReturnValues.get(0));
 
 			//Verify the responseConsentsMap can be modified
-			SAMPLE_CONSENTS_MAP.put("newkey", "newvalue");
+			verifyConsentMap.put("newkey", "newvalue");
 			callbackReturnValues.get(0).put("newkey", "newvalue");
-			assertEquals(SAMPLE_CONSENTS_MAP, callbackReturnValues.get(0));
-		}
-	}
-
-	@Test
-	public void testGetConsentsModifyConsentCallbackWithInvalidValue() {
-		try (MockedStatic<MobileCore> mobileCoreMockedStatic = Mockito.mockStatic(MobileCore.class)) {
-			// setup
-			final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-			final ArgumentCaptor<AdobeCallbackWithError<Event>> callbackCaptor = ArgumentCaptor.forClass(
-				AdobeCallbackWithError.class
-			);
-
-			final List<Map<String, Object>> callbackReturnValues = new ArrayList<>();
-
-			// test
-			Consent.getConsents(
-				new AdobeCallback<Map<String, Object>>() {
-					@Override
-					public void call(Map<String, Object> stringObjectMap) {
-						callbackReturnValues.add(stringObjectMap);
-					}
-				}
-			);
-
-			// verify
-			mobileCoreMockedStatic.verify(() ->
-				MobileCore.dispatchEventWithResponseCallback(
-					eventCaptor.capture(),
-					ArgumentMatchers.anyLong(),
-					callbackCaptor.capture()
-				)
-			);
-
-			final AdobeCallbackWithError<Event> callbackWithError = callbackCaptor.getValue();
-
-			//Verify callback responses with a invalid value
-			class CustomObj {
-
-				private final int value;
-
-				CustomObj(int value) {
-					this.value = value;
-				}
-			}
-
-			SAMPLE_CONSENTS_MAP.put("key2", "value2");
-			SAMPLE_CONSENTS_MAP.put("key3", new CustomObj(1000));
-			callbackWithError.call(buildConsentResponseEvent(SAMPLE_CONSENTS_MAP));
+			assertEquals(verifyConsentMap, callbackReturnValues.get(0));
 		}
 	}
 

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
@@ -303,6 +303,54 @@ public class ConsentTest {
 		}
 	}
 
+	@Test
+	public void testGetConsentsModifyConsentCallbackWithInvalidValue() {
+		try (MockedStatic<MobileCore> mobileCoreMockedStatic = Mockito.mockStatic(MobileCore.class)) {
+			// setup
+			final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+			final ArgumentCaptor<AdobeCallbackWithError<Event>> callbackCaptor = ArgumentCaptor.forClass(
+				AdobeCallbackWithError.class
+			);
+
+			final List<Map<String, Object>> callbackReturnValues = new ArrayList<>();
+
+			// test
+			Consent.getConsents(
+				new AdobeCallback<Map<String, Object>>() {
+					@Override
+					public void call(Map<String, Object> stringObjectMap) {
+						callbackReturnValues.add(stringObjectMap);
+					}
+				}
+			);
+
+			// verify
+			mobileCoreMockedStatic.verify(() ->
+				MobileCore.dispatchEventWithResponseCallback(
+					eventCaptor.capture(),
+					ArgumentMatchers.anyLong(),
+					callbackCaptor.capture()
+				)
+			);
+
+			final AdobeCallbackWithError<Event> callbackWithError = callbackCaptor.getValue();
+
+			//Verify callback responses with a invalid value
+			class CustomObj {
+
+				private final int value;
+
+				CustomObj(int value) {
+					this.value = value;
+				}
+			}
+
+			SAMPLE_CONSENTS_MAP.put("key2", "value2");
+			SAMPLE_CONSENTS_MAP.put("key3", new CustomObj(1000));
+			callbackWithError.call(buildConsentResponseEvent(SAMPLE_CONSENTS_MAP));
+		}
+	}
+
 	// ========================================================================================
 	// Private method
 	// ========================================================================================

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
@@ -294,16 +294,6 @@ public class ConsentTest {
 			final Event dispatchedEvent = eventCaptor.getValue();
 			final AdobeCallbackWithError<Event> callbackWithError = callbackCaptor.getValue();
 
-			// verify the dispatched event details
-			assertEquals(ConsentConstants.EventNames.GET_CONSENTS_REQUEST, dispatchedEvent.getName());
-			assertEquals(EventType.CONSENT, dispatchedEvent.getType());
-			assertEquals(EventSource.REQUEST_CONTENT, dispatchedEvent.getSource());
-			final Map<String, Object> eventData = dispatchedEvent.getEventData();
-			assertEquals(null, eventData);
-			//verify callback responses
-			callbackWithError.call(buildConsentResponseEvent(SAMPLE_CONSENTS_MAP));
-			assertEquals(SAMPLE_CONSENTS_MAP, callbackReturnValues.get(0));
-
 			//Verify the responseConsentsMap can be modified
 			SAMPLE_CONSENTS_MAP.put("newkey", "newvalue");
 			callbackReturnValues.get(0).put("newkey", "newvalue");

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentTest.java
@@ -291,8 +291,10 @@ public class ConsentTest {
 				)
 			);
 
-			final Event dispatchedEvent = eventCaptor.getValue();
 			final AdobeCallbackWithError<Event> callbackWithError = callbackCaptor.getValue();
+
+			callbackWithError.call(buildConsentResponseEvent(SAMPLE_CONSENTS_MAP));
+			assertEquals(SAMPLE_CONSENTS_MAP, callbackReturnValues.get(0));
 
 			//Verify the responseConsentsMap can be modified
 			SAMPLE_CONSENTS_MAP.put("newkey", "newvalue");

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentsTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.adobe.marketing.mobile.util.TimeUtils;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -121,6 +122,23 @@ public class ConsentsTest {
 
 		// verify
 		assertTrue(consents.isEmpty());
+	}
+
+	@Test
+	public void test_ConsentsCreation_With_ImmutableMap() {
+		// setup
+		Map<String, Object> xdmMap = CreateConsentXDMMap("y", "y");
+		Map<String, Object> immutableXdmMap = Collections.unmodifiableMap(xdmMap);
+		Consents baseConsent = new Consents(immutableXdmMap);
+
+		// test
+		Consents overridingConsent = new Consents(CreateConsentXDMMap("n", "n", SAMPLE_METADATA_TIMESTAMP));
+		baseConsent.merge(overridingConsent);
+
+		//verify
+		assertEquals("n", ConsentTestUtil.readCollectConsent(baseConsent));
+		assertEquals("n", ConsentTestUtil.readAdIdConsent(baseConsent));
+		assertEquals(SAMPLE_METADATA_TIMESTAMP, ConsentTestUtil.readTimestamp(baseConsent));
 	}
 
 	// ========================================================================================

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/UtilsTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/UtilsTest.java
@@ -1,0 +1,105 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.edge.consent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UtilsTest {
+
+	@Test
+	public void testDeepCopy_whenNull() {
+		assertNull(Utils.deepCopy((Map) null));
+	}
+
+	@Test
+	public void testDeepCopy_whenEmpty() {
+		Map<String, Object> emptyMap = new HashMap<>();
+		assertEquals(0, Utils.deepCopy(emptyMap).size());
+	}
+
+	@Test
+	public void testDeepCopy_whenValidSimple_thenSetOriginalNull() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("key1", "value1");
+		Map<String, Object> deepCopy = Utils.deepCopy(map);
+
+		map = null;
+		assertNotNull(deepCopy);
+	}
+
+	@Test
+	public void testDeepCopy_whenValidSimple_thenMutateOriginal() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("key1", "value1");
+
+		Map<String, Object> deepCopy = Utils.deepCopy(map);
+		deepCopy.remove("key1");
+
+		assertTrue(map.containsKey("key1"));
+	}
+
+	@Test
+	public void testDeepCopy_whenValidNested() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("key1", "value1");
+
+		Map<String, Object> nested = new HashMap<>();
+		nested.put("nestedKey", "nestedValue");
+		map.put("nestedMap", nested);
+
+		Map<String, Object> deepCopy = Utils.deepCopy(map);
+		Map<String, Object> nestedDeepCopy = (Map<String, Object>) deepCopy.get("nestedMap");
+		nestedDeepCopy.put("newKey", "newValue");
+
+		assertFalse(nested.size() == nestedDeepCopy.size());
+	}
+
+	@Test
+	public void testDeepCopy_whenNullKey_ignoresKey() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("key1", "value1");
+		map.put(null, "null");
+
+		Map<String, Object> result = Utils.deepCopy(map);
+		assertEquals(1, result.size());
+		assertEquals("value1", result.get("key1"));
+	}
+
+	@Test
+	public void testDeepCopy_whenInvalidMapWithCustomObjects_returnsNullAndNoThrow() {
+		class CustomObj {
+
+			private final int value;
+
+			CustomObj(int value) {
+				this.value = value;
+			}
+		}
+		Map<String, Object> map = new HashMap<>();
+		map.put("key1", "value1");
+		map.put("key2", new CustomObj(1000));
+
+		Map<String, Object> deepCopy = Utils.deepCopy(map);
+		assertNull(deepCopy);
+	}
+}

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/UtilsTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/UtilsTest.java
@@ -102,4 +102,17 @@ public class UtilsTest {
 		Map<String, Object> deepCopy = Utils.deepCopy(map);
 		assertNull(deepCopy);
 	}
+
+	@Test
+	public void testOptDeepCopy_whenNull_fallbackNull() {
+		assertNull(Utils.optDeepCopy(null, null));
+	}
+
+	@Test
+	public void testOptDeepCopy_whenNull_fallbackEmptyMap() {
+		Map<String, Object> emptyMap = new HashMap<>();
+		Map<String, Object> copyMap = Utils.optDeepCopy(null, emptyMap);
+		assertNotNull(copyMap);
+		assertEquals(emptyMap, copyMap);
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make a clone for callback event data, so getConsent response can be mutable. 
Add an unit test.
Add nonnull annotation to public API

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
