### PR TITLE
Only dispatch consent preferences on change, if configuration set to do so.

### DIFF
--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
@@ -20,6 +20,13 @@ final class ConsentConstants {
 
 	private ConsentConstants() {}
 
+	static final class Defaults {
+		// Default value for the forceSync flag, false means the SDK will only sync if preferences have changed.
+		static final boolean FORCE_SYNC = false;
+		// The interval to ignore consecutive consent updates, in milliseconds.
+		static final long IGNORE_CONSENT_UPDATE_INTERVAL_MS = 1000; // 1 second
+	}
+
 	static final class EventDataKey {
 
 		static final String CONSENTS = "consents";
@@ -53,6 +60,7 @@ final class ConsentConstants {
 	static final class ConfigurationKey {
 
 		static final String DEFAULT_CONSENT = "consent.default";
+		static final String CONSENT_FORCE_SYNC = "consent.forceSync";
 
 		private ConfigurationKey() {}
 	}

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
@@ -21,6 +21,7 @@ final class ConsentConstants {
 	private ConsentConstants() {}
 
 	static final class Defaults {
+
 		// Default value for the forceSync flag, false means the SDK will only sync if preferences have changed.
 		static final boolean FORCE_SYNC = false;
 		// The interval to ignore consecutive consent updates, in milliseconds.

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentConstants.java
@@ -60,6 +60,7 @@ final class ConsentConstants {
 
 	static final class ConfigurationKey {
 
+		static final String STATE_OWNER_NAME = "com.adobe.module.configuration";
 		static final String DEFAULT_CONSENT = "consent.default";
 		static final String CONSENT_FORCE_SYNC = "consent.forceSync";
 

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
@@ -181,13 +181,6 @@ class ConsentExtension extends Extension {
 			return;
 		}
 
-		// check if the forceSync flag is set to true
-		boolean forceSync = DataReader.optBoolean(
-			consentData,
-			ConsentConstants.ConfigurationKey.CONSENT_FORCE_SYNC,
-			ConsentConstants.Defaults.FORCE_SYNC
-		);
-
 		// set the timestamp and merge with existing consents
 		newConsents.setTimestamp(event.getTimestamp());
 		// Only proceed with Edge event dispatch if preferences actually changed

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
@@ -176,11 +176,11 @@ class ConsentExtension extends Extension {
 
 		// set the timestamp and merge with existing consents
 		newConsents.setTimestamp(event.getTimestamp());
-		consentManager.mergeAndPersist(newConsents);
-
-		// share and dispatch the updated consents
-		shareCurrentConsents(event);
-		dispatchEdgeConsentUpdateEvent(newConsents); // dispatches only the newly updated consents
+		if (consentManager.mergeAndPersist(newConsents)) {
+			// share and dispatch the updated consents
+			shareCurrentConsents(event);
+			dispatchEdgeConsentUpdateEvent(newConsents); // dispatches only the newly updated consents
+		}
 	}
 
 	/**

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentExtension.java
@@ -34,7 +34,7 @@ class ConsentExtension extends Extension {
 	private final ConsentManager consentManager;
 
 	// The forceSync flag, false means the SDK will only sync if preferences have changed.
-    // Flag updated via configuration shared state.
+	// Flag updated via configuration shared state.
 	private boolean forceSync = false;
 
 	// The last time a consent update was processed from public API.
@@ -182,7 +182,11 @@ class ConsentExtension extends Extension {
 		}
 
 		// check if the forceSync flag is set to true
-		boolean forceSync = DataReader.optBoolean(consentData, ConsentConstants.ConfigurationKey.CONSENT_FORCE_SYNC, ConsentConstants.Defaults.FORCE_SYNC);	
+		boolean forceSync = DataReader.optBoolean(
+			consentData,
+			ConsentConstants.ConfigurationKey.CONSENT_FORCE_SYNC,
+			ConsentConstants.Defaults.FORCE_SYNC
+		);
 
 		// set the timestamp and merge with existing consents
 		newConsents.setTimestamp(event.getTimestamp());
@@ -331,7 +335,12 @@ class ConsentExtension extends Extension {
 		}
 
 		// update the forceSync flag from configuration shared state
-		this.forceSync = DataReader.optBoolean(configData, ConsentConstants.ConfigurationKey.CONSENT_FORCE_SYNC, ConsentConstants.Defaults.FORCE_SYNC);
+		this.forceSync =
+			DataReader.optBoolean(
+				configData,
+				ConsentConstants.ConfigurationKey.CONSENT_FORCE_SYNC,
+				ConsentConstants.Defaults.FORCE_SYNC
+			);
 	}
 
 	/**
@@ -414,7 +423,8 @@ class ConsentExtension extends Extension {
 			return false;
 		}
 
-		return event.getTimestamp() > lastConsentUpdateTime + ConsentConstants.Defaults.IGNORE_CONSENT_UPDATE_INTERVAL_MS;
+		return (
+			event.getTimestamp() > lastConsentUpdateTime + ConsentConstants.Defaults.IGNORE_CONSENT_UPDATE_INTERVAL_MS
+		);
 	}
-
 }

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentManager.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentManager.java
@@ -53,7 +53,7 @@ final class ConsentManager {
 	 * Merges the provided {@link Consents} with {@link #userOptedConsents} and persists them.
 	 *
 	 * @param newConsents the newly obtained consents that needs to be merged with existing consents
-	 * @return true if `currentConsents` has been updated as a result of merging
+	 * @return true if `currentConsents` has been updated as a result of merging; ignores differences in timestamp values.
 	 */
 	boolean mergeAndPersist(final Consents newConsents) {
 		// hold temp copy of current consents for comparison

--- a/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentManager.java
+++ b/code/edgeconsent/src/main/java/com/adobe/marketing/mobile/edge/consent/ConsentManager.java
@@ -53,11 +53,18 @@ final class ConsentManager {
 	 * Merges the provided {@link Consents} with {@link #userOptedConsents} and persists them.
 	 *
 	 * @param newConsents the newly obtained consents that needs to be merged with existing consents
+	 * @return true if `currentConsents` has been updated as a result of merging
 	 */
-	void mergeAndPersist(final Consents newConsents) {
+	boolean mergeAndPersist(final Consents newConsents) {
+		// hold temp copy of current consents for comparison
+		final Consents currentConsents = getCurrentConsents();
+
 		// merge and persist
 		userOptedConsents.merge(newConsents);
 		saveConsentsToPersistence(userOptedConsents);
+
+		// return true if currentConsents has been updated as a result of merging
+		return !currentConsents.equalsIgnoreTimestamp(getCurrentConsents());
 	}
 
 	/**

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentExtensionTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentExtensionTest.java
@@ -30,7 +30,6 @@ import com.adobe.marketing.mobile.ExtensionEventListener;
 import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.util.JSONUtils;
 import com.adobe.marketing.mobile.util.TimeUtils;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -419,8 +418,12 @@ public class ConsentExtensionTest {
 
 		// verify consent response event has correct timestamp
 		Event consentResponseEvent = eventCaptor.getAllValues().get(0);
-		Map<String, Object> metadata = (Map) ((Map) consentResponseEvent.getEventData().get("consents")).get("metadata");
-		final String expectedTimestamp = TimeUtils.getISO8601UTCDateWithMilliseconds(new Date(consentUpdateEvent.getTimestamp()));
+		Map<String, Object> metadata = (Map) ((Map) consentResponseEvent.getEventData().get("consents")).get(
+				"metadata"
+			);
+		final String expectedTimestamp = TimeUtils.getISO8601UTCDateWithMilliseconds(
+			new Date(consentUpdateEvent.getTimestamp())
+		);
 		assertEquals(expectedTimestamp, metadata.get("time"));
 	}
 
@@ -452,7 +455,9 @@ public class ConsentExtensionTest {
 	public void test_handleConsentUpdate_SameConsentValuesNotDispatched() {
 		// setup
 		Event consentUpdateEvent = buildConsentUpdateEvent("y", "n");
-		final String isoTimestamp = TimeUtils.getISO8601UTCDateWithMilliseconds(new Date(consentUpdateEvent.getTimestamp()));
+		final String isoTimestamp = TimeUtils.getISO8601UTCDateWithMilliseconds(
+			new Date(consentUpdateEvent.getTimestamp())
+		);
 
 		setupExistingConsents(CreateConsentsXDMJSONString("y", "n", isoTimestamp));
 		ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
@@ -468,7 +473,9 @@ public class ConsentExtensionTest {
 	public void test_handleConsentUpdate_SameConsentValuesDifferentTimestampNotDispatched() throws Exception {
 		// setup
 		Event consentUpdateEvent = buildConsentUpdateEvent("y", "n");
-		final String isoTimestamp = TimeUtils.getISO8601UTCDateWithMilliseconds(new Date(consentUpdateEvent.getTimestamp() - 10000)); // move timestamp 10 seconds back
+		final String isoTimestamp = TimeUtils.getISO8601UTCDateWithMilliseconds(
+			new Date(consentUpdateEvent.getTimestamp() - 10000)
+		); // move timestamp 10 seconds back
 
 		setupExistingConsents(CreateConsentsXDMJSONString("y", "n", isoTimestamp));
 		ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
@@ -505,7 +512,8 @@ public class ConsentExtensionTest {
 	}
 
 	@Test
-	public void test_handleConsentUpdate_doesNotDispatchEdgeEventIfForceSyncIsTrue_andConsentUpdateIsOutsideIgnoreInterval() throws Exception {
+	public void test_handleConsentUpdate_doesNotDispatchEdgeEventIfForceSyncIsTrue_andConsentUpdateIsOutsideIgnoreInterval()
+		throws Exception {
 		// setup
 		setupExistingConsents(CreateConsentsXDMJSONString("y", "n"));
 
@@ -527,7 +535,7 @@ public class ConsentExtensionTest {
 		extension.handleConsentUpdate(repeatConsentUpdateEvent);
 
 		// verify, expect new events to be dispatched as the timestamp is outside the ignore interval
-		verify(mockExtensionApi, times(4)).dispatch(eventCaptor.capture()); 
+		verify(mockExtensionApi, times(4)).dispatch(eventCaptor.capture());
 	}
 
 	@Test
@@ -919,7 +927,11 @@ public class ConsentExtensionTest {
 	private Event buildConfigUpdateForceSyncEvent(final boolean forceSync) {
 		Map<String, Object> eventData = new HashMap<>();
 		eventData.put(ConsentConstants.ConfigurationKey.CONSENT_FORCE_SYNC, forceSync);
-		return new Event.Builder("Configuration Update Force Sync", EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT)
+		return new Event.Builder(
+			"Configuration Update Force Sync",
+			EventType.CONFIGURATION,
+			EventSource.RESPONSE_CONTENT
+		)
 			.setEventData(eventData)
 			.build();
 	}

--- a/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentExtensionTest.java
+++ b/code/edgeconsent/src/test/java/com/adobe/marketing/mobile/edge/consent/ConsentExtensionTest.java
@@ -530,6 +530,31 @@ public class ConsentExtensionTest {
 		verify(mockExtensionApi, times(4)).dispatch(eventCaptor.capture()); 
 	}
 
+	@Test
+	public void test_handleConsentUpdate_dispatchesEdgeEventIfForceSyncIsTrue_andConsentUpdateIsDifferent() {
+		// setup
+		setupExistingConsents(CreateConsentsXDMJSONString("y", "n"));
+
+		Event consentUpdateEvent = buildConsentUpdateEvent("y", "n");
+		ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+
+		Event configEvent = buildConfigUpdateForceSyncEvent(true); // forceSync = true dispatches events on every update request
+		extension.handleConfigurationResponse(configEvent);
+
+		// test, send consent update event with same values
+		extension.handleConsentUpdate(consentUpdateEvent);
+
+		// verify, expect 2 events to be dispatched
+		verify(mockExtensionApi, times(2)).dispatch(eventCaptor.capture());
+
+		// test, send consent update event with new values
+		Event newConsentUpdateEvent = buildConsentUpdateEvent("y", "y");
+		extension.handleConsentUpdate(newConsentUpdateEvent);
+
+		// verify, expect two new events to be dispatched as values changed even though the timestamp is within the ignore interval
+		verify(mockExtensionApi, times(4)).dispatch(eventCaptor.capture());
+	}
+
 	// ========================================================================================
 	// handleRequestContent
 	// ========================================================================================


### PR DESCRIPTION

## Description

Optimizes Consent to only dispatch consent preference Edge events when the values change. This will reduce the number of network requests made when the preferences do not change.

- Adds a new boolean configuration flag consent.forceSync which if false (default) will only dispatch an Edge request event if the consent preferences change. If true, preserves the current behavior and dispatches an Edge request on each Consent update request.
- Adds a sanity check to the current behavior (i.e. consent.forceSync = true) where if two Consent update requests with duplicate values are sent within a second of each other, the Edge request is not sent. This optimizes application implementation which may incorrectly make the same API call several times within a second.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
